### PR TITLE
feat: 裏返す処理の実装

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -2,124 +2,12 @@ import React, { useState } from 'react'
 import { Square } from '@/components/Square'
 import styled from '@emotion/styled'
 import { BoardType, Turn } from '@/types/global'
+import { getInitialBoard, getMovableDir, getMovablePos } from '@/scripts/functions'
 
 export type BoardProps = {
   firstTurn: Turn
   /* 盤面サイズ（偶数） */
   size: number
-}
-
-export const getInitialBoard = (size: number): BoardType => {
-  const includeWallSize = size + 2
-  const board = [...Array(includeWallSize)].map((_, yIdx) => {
-    if (yIdx === 0 || yIdx === includeWallSize - 1) {
-      return [...Array(includeWallSize)].fill(2)
-    } else {
-      return [2, ...Array(size).fill(0), 2]
-    }
-  })
-
-  board[includeWallSize / 2][includeWallSize / 2 - 1] = 1
-  board[includeWallSize / 2 - 1][includeWallSize / 2] = 1
-  board[includeWallSize / 2 - 1][includeWallSize / 2 - 1] = -1
-  board[includeWallSize / 2][includeWallSize / 2] = -1
-
-  return board
-}
-
-const getMovableDir = (board: BoardType, currentTurn: Turn): number[][] => {
-  return board.map((y, yIdx) => y.map((value, xIdx) => checkMobility(board, yIdx, xIdx, currentTurn)))
-}
-const getMovablePos = (board: BoardType, currentTurn: Turn): boolean[][] => {
-  return board.map((y, yIdx) =>
-    y.map((value, xIdx) => {
-      const dir = checkMobility(board, yIdx, xIdx, currentTurn)
-      return dir !== 0
-    }),
-  )
-}
-
-const checkMobility = (board: BoardType, y: number, x: number, value: number): number => {
-  let direction = 0
-  // 空マスじゃない場合
-  if (board[y][x] !== 0) return direction
-  // 左
-  if (board[y][x - 1] === -value) {
-    const yTmp = y
-    let xTmp = x - 2
-    while (board[yTmp][xTmp] === -value) {
-      xTmp -= 1
-    }
-    if (board[yTmp][xTmp] === value) direction = direction | 1
-  }
-  // 左上
-  if (board[y + 1][x - 1] === -value) {
-    let yTmp = y + 2
-    let xTmp = x - 2
-    while (board[yTmp][xTmp] === -value) {
-      yTmp += 1
-      xTmp -= 1
-    }
-    if (board[yTmp][xTmp] === value) direction = direction | 2
-  }
-  // 上
-  if (board[y - 1][x] === -value) {
-    let yTemp = y - 2
-    const xTemp = x
-    while (board[yTemp][xTemp] === -value) {
-      yTemp -= 1
-    }
-    if (board[yTemp][xTemp] === value) direction = direction | 4
-  }
-  // 右上
-  if (board[y - 1][x - 1] === -value) {
-    let yTmp = y - 2
-    let xTmp = x - 2
-    while (board[yTmp][xTmp] === -value) {
-      yTmp -= 1
-      xTmp -= 1
-    }
-    if (board[yTmp][xTmp] === value) direction = direction | 8
-  }
-  // 右
-  if (board[y][x + 1] === -value) {
-    const yTmp = y
-    let xTmp = x + 2
-    while (board[yTmp][xTmp] === -value) {
-      xTmp += 1
-    }
-    if (board[yTmp][xTmp] === value) direction = direction | 16
-  }
-  // 右下
-  if (board[y + 1][x + 1] === -value) {
-    let yTmp = y + 2
-    let xTmp = x + 2
-    while (board[yTmp][xTmp] === -value) {
-      yTmp += 1
-      xTmp += 1
-    }
-    if (board[yTmp][xTmp] === value) direction = direction | 32
-  }
-  // 下
-  if (board[y + 1][x] === -value) {
-    let yTmp = y + 2
-    const xTmp = x
-    while (board[yTmp][xTmp] === -value) {
-      yTmp += 1
-    }
-    if (board[yTmp][xTmp] === value) direction = direction | 64
-  }
-  // 左下
-  if (board[y - 1][x + 1] === -value) {
-    let yTmp = y - 2
-    let xTmp = x + 2
-    while (board[yTmp][xTmp] === -value) {
-      yTmp -= 1
-      xTmp += 1
-    }
-    if (board[yTmp][xTmp] === value) direction = direction | 128
-  }
-  return direction
 }
 
 export const Board: React.FC<BoardProps> = React.memo(({ firstTurn, size }) => {

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Square } from '@/components/Square'
 import styled from '@emotion/styled'
 import { BoardType, Turn } from '@/types/global'
-import { getInitialBoard, getMovableDir, getMovablePos } from '@/scripts/functions'
+import { getFlippedBoard, getInitialBoard, getMovableDir, getMovablePos } from '@/scripts/functions'
 
 export type BoardProps = {
   firstTurn: Turn
@@ -20,7 +20,7 @@ export const Board: React.FC<BoardProps> = React.memo(({ firstTurn, size }) => {
 
   const items = board.map((y, yIdx) =>
     y.map((x, xIdx) => {
-      const key = `area${yIdx}${xIdx}`
+      const key = `area${xIdx}_${yIdx}`
       return (
         <StyledGridItem key={key} area={key} onClick={() => handleClick(yIdx, xIdx)}>
           <Square state={x} />
@@ -36,21 +36,26 @@ export const Board: React.FC<BoardProps> = React.memo(({ firstTurn, size }) => {
    * @param {number} x
    */
   const handleClick = (y: number, x: number) => {
-    const newBoard = [...board]
     const nextTurn: Turn = currentTurn === 1 ? -1 : 1
     if (getMovablePos(board, currentTurn)[y][x]) {
-      newBoard[y][x] = currentTurn
+      const newBoard = getFlippedBoard({
+        board,
+        x,
+        y,
+        dir: getMovableDir(board, currentTurn)[y][x],
+        currentTurn,
+      })
+      setBoard([...newBoard])
       setNextTurn(nextTurn)
-      setBoard(newBoard)
-      setMovableDir(getMovableDir(newBoard, nextTurn))
-      setMovablePos(getMovablePos(newBoard, nextTurn))
+      setMovableDir([...getMovableDir(newBoard, nextTurn)])
+      setMovablePos([...getMovablePos(newBoard, nextTurn)])
     }
   }
 
   return (
     <>
       currentTurn: {currentTurn}
-      <StyledGridContainer columns={sizes} rows={sizes} areas={board.map((r, i) => r.map((c, j) => `area${i}${j}`))}>
+      <StyledGridContainer columns={sizes} rows={sizes} areas={board.map((y, yIdx) => y.map((x, xIdx) => `area${xIdx}_${yIdx}`))}>
         {items}
       </StyledGridContainer>
       {movableDir.map((r, i) => (

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,20 +1,15 @@
 import React, { useState } from 'react'
 import { Square } from '@/components/Square'
 import styled from '@emotion/styled'
-import SquareState from '@/types/SquareState'
+import { BoardType, Turn } from '@/types/global'
 
-/* 最初のターン - 1: 自分, -1: 相手 */
-type Turn = 1 | -1
-
-type BoardProps = {
+export type BoardProps = {
   firstTurn: Turn
   /* 盤面サイズ（偶数） */
   size: number
 }
 
-type BoardType = SquareState[][]
-
-const getInitialBoard = (size: number): BoardType => {
+export const getInitialBoard = (size: number): BoardType => {
   const includeWallSize = size + 2
   const board = [...Array(includeWallSize)].map((_, yIdx) => {
     if (yIdx === 0 || yIdx === includeWallSize - 1) {

--- a/src/components/Square.tsx
+++ b/src/components/Square.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { css } from '@emotion/react'
-import SquareState from '@/types/SquareState'
+import { SquareState } from '@/types/global'
 
 export type SquareProps = {
   state: SquareState

--- a/src/scripts/functions.ts
+++ b/src/scripts/functions.ts
@@ -1,0 +1,115 @@
+import { BoardType, Turn } from '@/types/global'
+
+export const getInitialBoard = (size: number): BoardType => {
+  const includeWallSize = size + 2
+  const board = [...Array(includeWallSize)].map((_, yIdx) => {
+    if (yIdx === 0 || yIdx === includeWallSize - 1) {
+      return [...Array(includeWallSize)].fill(2)
+    } else {
+      return [2, ...Array(size).fill(0), 2]
+    }
+  })
+
+  board[includeWallSize / 2][includeWallSize / 2 - 1] = 1
+  board[includeWallSize / 2 - 1][includeWallSize / 2] = 1
+  board[includeWallSize / 2 - 1][includeWallSize / 2 - 1] = -1
+  board[includeWallSize / 2][includeWallSize / 2] = -1
+
+  return board
+}
+
+export const getMovableDir = (board: BoardType, currentTurn: Turn): number[][] => {
+  return board.map((y, yIdx) => y.map((value, xIdx) => checkMobility(board, yIdx, xIdx, currentTurn)))
+}
+
+export const getMovablePos = (board: BoardType, currentTurn: Turn): boolean[][] => {
+  return board.map((y, yIdx) =>
+    y.map((value, xIdx) => {
+      const dir = checkMobility(board, yIdx, xIdx, currentTurn)
+      return dir !== 0
+    }),
+  )
+}
+
+export const checkMobility = (board: BoardType, y: number, x: number, value: number): number => {
+  let direction = 0
+  // 空マスじゃない場合
+  if (board[y][x] !== 0) return direction
+  // 左
+  if (board[y][x - 1] === -value) {
+    const yTmp = y
+    let xTmp = x - 2
+    while (board[yTmp][xTmp] === -value) {
+      xTmp -= 1
+    }
+    if (board[yTmp][xTmp] === value) direction = direction | 1
+  }
+  // 左上
+  if (board[y + 1][x - 1] === -value) {
+    let yTmp = y + 2
+    let xTmp = x - 2
+    while (board[yTmp][xTmp] === -value) {
+      yTmp += 1
+      xTmp -= 1
+    }
+    if (board[yTmp][xTmp] === value) direction = direction | 2
+  }
+  // 上
+  if (board[y - 1][x] === -value) {
+    let yTemp = y - 2
+    const xTemp = x
+    while (board[yTemp][xTemp] === -value) {
+      yTemp -= 1
+    }
+    if (board[yTemp][xTemp] === value) direction = direction | 4
+  }
+  // 右上
+  if (board[y - 1][x - 1] === -value) {
+    let yTmp = y - 2
+    let xTmp = x - 2
+    while (board[yTmp][xTmp] === -value) {
+      yTmp -= 1
+      xTmp -= 1
+    }
+    if (board[yTmp][xTmp] === value) direction = direction | 8
+  }
+  // 右
+  if (board[y][x + 1] === -value) {
+    const yTmp = y
+    let xTmp = x + 2
+    while (board[yTmp][xTmp] === -value) {
+      xTmp += 1
+    }
+    if (board[yTmp][xTmp] === value) direction = direction | 16
+  }
+  // 右下
+  if (board[y + 1][x + 1] === -value) {
+    let yTmp = y + 2
+    let xTmp = x + 2
+    while (board[yTmp][xTmp] === -value) {
+      yTmp += 1
+      xTmp += 1
+    }
+    if (board[yTmp][xTmp] === value) direction = direction | 32
+  }
+  // 下
+  if (board[y + 1][x] === -value) {
+    let yTmp = y + 2
+    const xTmp = x
+    while (board[yTmp][xTmp] === -value) {
+      yTmp += 1
+    }
+    if (board[yTmp][xTmp] === value) direction = direction | 64
+  }
+  // 左下
+  if (board[y - 1][x + 1] === -value) {
+    let yTmp = y - 2
+    let xTmp = x + 2
+    while (board[yTmp][xTmp] === -value) {
+      yTmp -= 1
+      xTmp += 1
+    }
+    if (board[yTmp][xTmp] === value) direction = direction | 128
+  }
+  return direction
+}

--- a/src/scripts/functions.ts
+++ b/src/scripts/functions.ts
@@ -31,85 +31,177 @@ export const getMovablePos = (board: BoardType, currentTurn: Turn): boolean[][] 
   )
 }
 
-export const checkMobility = (board: BoardType, y: number, x: number, value: number): number => {
+export const checkMobility = (board: BoardType, y: number, x: number, currentTurn: number): number => {
   let direction = 0
   // 空マスじゃない場合
   if (board[y][x] !== 0) return direction
   // 左
-  if (board[y][x - 1] === -value) {
+  if (board[y][x - 1] === -currentTurn) {
     const yTmp = y
     let xTmp = x - 2
-    while (board[yTmp][xTmp] === -value) {
+    while (board[yTmp][xTmp] === -currentTurn) {
       xTmp -= 1
     }
-    if (board[yTmp][xTmp] === value) direction = direction | 1
+    if (board[yTmp][xTmp] === currentTurn) direction = direction | 1
   }
   // 左上
-  if (board[y + 1][x - 1] === -value) {
+  if (board[y + 1][x - 1] === -currentTurn) {
     let yTmp = y + 2
     let xTmp = x - 2
-    while (board[yTmp][xTmp] === -value) {
+    while (board[yTmp][xTmp] === -currentTurn) {
       yTmp += 1
       xTmp -= 1
     }
-    if (board[yTmp][xTmp] === value) direction = direction | 2
+    if (board[yTmp][xTmp] === currentTurn) direction = direction | 2
   }
   // 上
-  if (board[y - 1][x] === -value) {
+  if (board[y - 1][x] === -currentTurn) {
     let yTemp = y - 2
     const xTemp = x
-    while (board[yTemp][xTemp] === -value) {
+    while (board[yTemp][xTemp] === -currentTurn) {
       yTemp -= 1
     }
-    if (board[yTemp][xTemp] === value) direction = direction | 4
+    if (board[yTemp][xTemp] === currentTurn) direction = direction | 4
   }
   // 右上
-  if (board[y - 1][x - 1] === -value) {
+  if (board[y - 1][x - 1] === -currentTurn) {
     let yTmp = y - 2
     let xTmp = x - 2
-    while (board[yTmp][xTmp] === -value) {
+    while (board[yTmp][xTmp] === -currentTurn) {
       yTmp -= 1
       xTmp -= 1
     }
-    if (board[yTmp][xTmp] === value) direction = direction | 8
+    if (board[yTmp][xTmp] === currentTurn) direction = direction | 8
   }
   // 右
-  if (board[y][x + 1] === -value) {
+  if (board[y][x + 1] === -currentTurn) {
     const yTmp = y
     let xTmp = x + 2
-    while (board[yTmp][xTmp] === -value) {
+    while (board[yTmp][xTmp] === -currentTurn) {
       xTmp += 1
     }
-    if (board[yTmp][xTmp] === value) direction = direction | 16
+    if (board[yTmp][xTmp] === currentTurn) direction = direction | 16
   }
   // 右下
-  if (board[y + 1][x + 1] === -value) {
+  if (board[y + 1][x + 1] === -currentTurn) {
     let yTmp = y + 2
     let xTmp = x + 2
-    while (board[yTmp][xTmp] === -value) {
+    while (board[yTmp][xTmp] === -currentTurn) {
       yTmp += 1
       xTmp += 1
     }
-    if (board[yTmp][xTmp] === value) direction = direction | 32
+    if (board[yTmp][xTmp] === currentTurn) direction = direction | 32
   }
   // 下
-  if (board[y + 1][x] === -value) {
+  if (board[y + 1][x] === -currentTurn) {
     let yTmp = y + 2
     const xTmp = x
-    while (board[yTmp][xTmp] === -value) {
+    while (board[yTmp][xTmp] === -currentTurn) {
       yTmp += 1
     }
-    if (board[yTmp][xTmp] === value) direction = direction | 64
+    if (board[yTmp][xTmp] === currentTurn) direction = direction | 64
   }
   // 左下
-  if (board[y - 1][x + 1] === -value) {
+  if (board[y - 1][x + 1] === -currentTurn) {
     let yTmp = y - 2
     let xTmp = x + 2
-    while (board[yTmp][xTmp] === -value) {
+    while (board[yTmp][xTmp] === -currentTurn) {
       yTmp -= 1
       xTmp += 1
     }
-    if (board[yTmp][xTmp] === value) direction = direction | 128
+    if (board[yTmp][xTmp] === currentTurn) direction = direction | 128
   }
   return direction
+}
+
+export const getFlippedBoard = ({
+  board,
+  x,
+  y,
+  dir,
+  currentTurn,
+} : {
+  board: BoardType
+  x: number
+  y: number
+  dir: number
+  currentTurn: Turn
+}): BoardType => {
+  const boardTemp = [...board]
+
+  boardTemp[y][x] = currentTurn
+
+  // 左
+  if (dir & 1) {
+    let xTmp = x - 1
+    while (boardTemp[y][xTmp] === -currentTurn) {
+      boardTemp[y][xTmp] = currentTurn
+      xTmp -= 1
+    }
+  }
+  // 左上
+  if (dir & 2) {
+    let xTmp = x - 1
+    let yTmp = y - 1
+    while (boardTemp[yTmp][xTmp] === -currentTurn) {
+      boardTemp[yTmp][xTmp] = currentTurn
+      xTmp -= 1
+      yTmp -= 1
+    }
+  }
+  // 上
+  if (dir & 4) {
+    let yTmp = y - 1
+    while (boardTemp[yTmp][x] === -currentTurn) {
+      boardTemp[yTmp][x] = currentTurn
+      yTmp -= 1
+    }
+  }
+  // 右上
+  if (dir & 8) {
+    let xTmp = x + 1
+    let yTmp = y - 1
+    while (boardTemp[yTmp][xTmp] === -currentTurn) {
+      boardTemp[yTmp][xTmp] = currentTurn
+      xTmp += 1
+      yTmp -= 1
+    }
+  }
+  // 右
+  if (dir & 16) {
+    let xTmp = x + 1
+    while (boardTemp[y][xTmp] === -currentTurn) {
+      boardTemp[y][xTmp] = currentTurn
+      xTmp += 1
+    }
+  }
+  // 右下
+  if (dir & 32) {
+    let xTmp = x + 1
+    let yTmp = y + 1
+    while (boardTemp[yTmp][xTmp] === -currentTurn) {
+      boardTemp[yTmp][xTmp] = currentTurn
+      xTmp += 1
+      yTmp += 1
+    }
+  }
+  // 下
+  if (dir & 64) {
+    let yTmp = y + 1
+    while (boardTemp[yTmp][x] === -currentTurn) {
+      boardTemp[yTmp][x] = currentTurn
+      yTmp += 1
+    }
+  }
+  // 左下
+  if (dir & 128) {
+    let xTmp = x - 1
+    let yTmp = y + 1
+    while (boardTemp[yTmp][xTmp] === -currentTurn) {
+      boardTemp[yTmp][xTmp] = currentTurn
+      xTmp -= 1
+      yTmp += 1
+    }
+  }
+  return boardTemp
 }

--- a/src/types/SquareState.ts
+++ b/src/types/SquareState.ts
@@ -1,3 +1,0 @@
-/* 0:空, -1:白, 1:黒, 2:壁 */
-type SquareState = 0 | -1 | 1 | 2
-export default SquareState

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,7 @@
+/* 0:空, -1:白, 1:黒, 2:壁 */
+export type SquareState = 0 | -1 | 1 | 2
+
+export type BoardType = SquareState[][]
+
+/* 最初のターン - 1: 自分, -1: 相手 */
+export type Turn = 1 | -1

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -3,5 +3,5 @@ export type SquareState = 0 | -1 | 1 | 2
 
 export type BoardType = SquareState[][]
 
-/* 最初のターン - 1: 自分, -1: 相手 */
+/* 1: 自分, -1: 相手 */
 export type Turn = 1 | -1


### PR DESCRIPTION
## 概要
裏返す処理の実装

## 詳細
- 型情報や関数を外部ファイルに移動
- `getFlippedBoard` の実装 裏返されたあとのボードの状態を返す
- `handleClick` で `getFlippedBoard` を実行
- 石を置く処理は getFlippedBoard 内に移動
- CSS Grid のエリア定義を修正